### PR TITLE
0.1.14 snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## Current
+### Added 
+- Recursively inject inline defs inside lambda  functions.
+- Insert inline defs inside lambda functions contained in methods and other functions
+
 ## [0.1.13] 2022-12-18
 ### Added
 - Support for binding forms like if-let, when-let, and other binding forms.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ This makes it very "ergonomic" for repl-driven development.
 ## defn*
 
 defn* walks your clojure form and injects inline defs for all the bindings in the form.
-This includes the arguments as well as bindings inside a let body. 
-It also supports some binding forms like `if-let` and `when-let` (only for clj though, still trying to figure out cljs for this).
+This includes the arguments as well as bindings inside a let body, and any lambda function. 
 
 ```clojure
 (require '[snitch.core :refer [defn*]])
@@ -146,8 +145,19 @@ injecting inline defs inside let forms
 a ; 1
 
 ```
+
+injecting inline defs inside lambda forms
+```clojure
+(defn* foobar [a]
+  ((fn [b] b) a))
+
+(foobar 4) ; 1
+a ; 4
+b ; 4
+```
+
 ## *let 
-*let will recursively inject inline defs for the all binding forms.
+*let will recursively inject inline defs for the all binding forms including any lambda forms.
 ```clojure
 (*let [a 1]
       (let [b 2]   ; this isn't a *let but the top-level *let injects inline defs for this as well

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.abhinav/snitch "0.1.13"
+(defproject org.clojars.abhinav/snitch "0.1.14-SNAPSHOT"
   :description
   "Snitch injects inline defs in your functions and multimethods.
                 This enables a repl-based, editor-agnostic, clojure and clojurescript debugging workflow. 

--- a/src/snitch/core.cljc
+++ b/src/snitch/core.cljc
@@ -411,6 +411,7 @@
   (let [result  (prewalk (fn [form]
                            (if (fn-form? form)
                              `(*fn ~@(rest form))
+
                              form))
                          forms)]
     result))
@@ -478,7 +479,7 @@
 (defmacro defn*
   "like defn but injects inline defs for arguments and any let bindings, or lambdas inside it."
   [name & forms]
-  (let [exp (macroexpand `(*fn ~@(cons name forms)))]
+  (let [exp (macroexpand* &env `(*fn ~@(cons name forms)))]
     (cons 'defn (rest exp))))
 
 
@@ -517,13 +518,13 @@
 
 
 
- #?(:clj (do (intern 'clojure.core (with-meta 'defn* (meta #'defn*)) #'defn*)
-             (intern 'clojure.core (with-meta '*fn (meta #'*fn)) #'*fn)
-             (intern 'clojure.core (with-meta 'defmethod* (meta #'defmethod*)) #'defmethod*)
-             (intern 'clojure.core (with-meta '*let (meta #'*let)) #'*let)
-             (try
-               (intern 'cljs.core (with-meta 'defn* (meta #'defn*)) #'defn*)
-               (intern 'cljs.core (with-meta '*fn (meta #'*fn)) #'*fn)
-               (intern 'cljs.core (with-meta 'defmethod* (meta #'defmethod*)) #'defmethod*)
-               (intern 'cljs.core (with-meta '*let (meta #'*let)) #'*let)
-               (catch Exception _))))
+#?(:clj (do (intern 'clojure.core (with-meta 'defn* (meta #'defn*)) #'defn*)
+            (intern 'clojure.core (with-meta '*fn (meta #'*fn)) #'*fn)
+            (intern 'clojure.core (with-meta 'defmethod* (meta #'defmethod*)) #'defmethod*)
+            (intern 'clojure.core (with-meta '*let (meta #'*let)) #'*let)
+            (try
+              (intern 'cljs.core (with-meta 'defn* (meta #'defn*)) #'defn*)
+              (intern 'cljs.core (with-meta '*fn (meta #'*fn)) #'*fn)
+              (intern 'cljs.core (with-meta 'defmethod* (meta #'defmethod*)) #'defmethod*)
+              (intern 'cljs.core (with-meta '*let (meta #'*let)) #'*let)
+              (catch Exception _))))

--- a/test/snitch/core_test.cljc
+++ b/test/snitch/core_test.cljc
@@ -8,7 +8,8 @@
       [cljs.test :refer [deftest is testing run-tests]]))
   #?(:cljs
      (:require-macros
-      [snitch.core])))
+      [snitch.core]
+      [snitch.core-test :refer [let-to-fn] ])))
 
 
 (deftest test-behaviour-of-defn*
@@ -273,7 +274,9 @@
     (is (= y 2))))
 
 
-:clj( (defmacro let-to-fn [bindings & body]
+
+
+     (defmacro let-to-fn [bindings & body]
     (->> (partition 2 bindings)
          reverse
          (reduce (fn [acc [binding-sym val]]
@@ -281,11 +284,6 @@
                      `((fn [~binding-sym] ~@acc) ~val)
                      `((fn [~binding-sym] ~acc) ~val)))
                  body))) 
-(comment
-  (macroexpand-1 '(let-to-fn [a 1 b 2]
-                             (+ a b))))
-
-
 
 (deftest custom-let-macros
   (let [_ (defn* fn-with-custom-let-macro [x]
@@ -294,9 +292,15 @@
                        (+ x z)))
         _ (fn-with-custom-let-macro 10)]
     (is (= y 10))
-    (is (= z 11)))))
-(defn* foobar [a]
-  ((fn [b] b) a))
+    (is (= z 11))))
+(comment
+  (macroexpand-1 '(let-to-fn [a 1 b 2]
+                             (+ a b))))
+
+
+
+
+
 
 (comment
   (macroexpand-1 '(defn* foo [{:keys [a]}]

--- a/test/snitch/core_test.cljc
+++ b/test/snitch/core_test.cljc
@@ -1,15 +1,14 @@
 (ns snitch.core-test
   #?(:clj
      (:require
-       [clojure.test :refer [deftest is testing]]
-       [snitch.core :refer [concat-symbols define-args defn* define-let-bindings defmethod*
-                            *let *fn]])
+      [clojure.test :refer [deftest is testing]]
+      [snitch.core :refer [concat-symbols define-args defn* define-let-bindings defmethod* *let *fn]])
      :cljs
      (:require
-       [cljs.test :refer [deftest is testing run-tests]]))
+      [cljs.test :refer [deftest is testing run-tests]]))
   #?(:cljs
      (:require-macros
-       [snitch.core])))
+      [snitch.core])))
 
 
 (deftest test-behaviour-of-defn*
@@ -56,6 +55,12 @@
                 x))
           _ (foo13)]
       (is (= 9 x))))
+
+  (testing "lambdas inside defn"
+    (let [_ (defn* foo-14 [a]
+              ((fn [x] (inc x)) a))
+          _ (foo-14 3)]
+      (is (= 3 x))))
 
 
   (testing "Destructuring namespaced keywords with ns/keys syntax"
@@ -150,56 +155,56 @@
   ;;   FIXME commenting out the history feature because it doesn't work in cljs yet.
   #_(testing "defn* stores history of the values.
             Calling var> returns the last 3 values."
-    (let [_ (defn* foo3 [foo3-p]
-              (let [foo3-a (inc foo3-p)]
-                #{foo3-p foo3-a}))
-          _ (foo3 1)
-          _ (foo3 2)
-          _ (foo3 3)
-          expected-foo3-p> '(3 2 1)
-          expected-foo3-a> '(4 3 2)
-          expected-foo3> {'foo3-p expected-foo3-p>
-                          'foo3-a  expected-foo3-a>}]
+      (let [_ (defn* foo3 [foo3-p]
+                (let [foo3-a (inc foo3-p)]
+                  #{foo3-p foo3-a}))
+            _ (foo3 1)
+            _ (foo3 2)
+            _ (foo3 3)
+            expected-foo3-p> '(3 2 1)
+            expected-foo3-a> '(4 3 2)
+            expected-foo3> {'foo3-p expected-foo3-p>
+                            'foo3-a  expected-foo3-a>}]
 
-      (is (= expected-foo3-p> foo3-p>))
-      (is (= expected-foo3-a> foo3-a>))
-      (is (= expected-foo3> foo3>))))
+        (is (= expected-foo3-p> foo3-p>))
+        (is (= expected-foo3-a> foo3-a>))
+        (is (= expected-foo3> foo3>))))
   ;;   FIXME commenting out the history feature because it doesn't work in cljs yet.
   #_(testing "defn* stores history of the values.
             Calling var>> with a number returns the last n values."
-    (let [_ (defn* foo4 [foo4-p]
-              foo4-p)
-          _ (foo4 1)
-          _ (foo4 2)
-          _ (foo4 3)
-          _ (foo4 4)
-          _ (foo4 5)
-          _ (foo4 6)
+      (let [_ (defn* foo4 [foo4-p]
+                foo4-p)
+            _ (foo4 1)
+            _ (foo4 2)
+            _ (foo4 3)
+            _ (foo4 4)
+            _ (foo4 5)
+            _ (foo4 6)
           ;; history is stored from most recent to least recent.
-          all-foo4-p-values '(6 5 4 3 2 1)]
-      (is (= (foo4-p>> 4)
-             (take 4 all-foo4-p-values)))
-      (is (= (foo4-p>> 5)
-             (take 5 all-foo4-p-values)))
-      (is (= (foo4-p>> 0)
-             (take 0 all-foo4-p-values)))))
+            all-foo4-p-values '(6 5 4 3 2 1)]
+        (is (= (foo4-p>> 4)
+               (take 4 all-foo4-p-values)))
+        (is (= (foo4-p>> 5)
+               (take 5 all-foo4-p-values)))
+        (is (= (foo4-p>> 0)
+               (take 0 all-foo4-p-values)))))
   ;;  FIXME commenting out the history feature because it doesn't work in cljs yet.
   #_(testing "calling fn-name! resets the atom"
-    (let [_ (defn* foo5 [foo5-p]
-              foo5-p)
-          _ (foo5 1)
-          _ (foo5 2)
-          _ (foo5 3)
-          _ (foo5 4)
-          _ (foo5 5)
-          _ (foo5 6)
-          atom-value-before-reset @foo5_
-          _ (foo5!) ; calling fn-name! to reset the atom
-          atom-value-after-reset  @foo5_]
+      (let [_ (defn* foo5 [foo5-p]
+                foo5-p)
+            _ (foo5 1)
+            _ (foo5 2)
+            _ (foo5 3)
+            _ (foo5 4)
+            _ (foo5 5)
+            _ (foo5 6)
+            atom-value-before-reset @foo5_
+            _ (foo5!) ; calling fn-name! to reset the atom
+            atom-value-after-reset  @foo5_]
 
-      (is (false? (empty? atom-value-before-reset)))
-      (is (= atom-value-after-reset
-             {})))))
+        (is (false? (empty? atom-value-before-reset)))
+        (is (= atom-value-after-reset
+               {})))))
 
 
 ;; FIXME: rename vars to follow convention.
@@ -234,7 +239,6 @@
     (is (= {:d11 :foomethod} b11))
     (is (= :foomethod d11))))
 
-
 (deftest test-*let
   (let [_ (*let [a 1
                  [b c] [2 3]]
@@ -250,30 +254,71 @@
                 [a b])
            1 2)]
     (is (= a 1))
-    (is (= b 2))))
+    (is (= b 2)))
+  (let [_ ((*fn [a b]
+                ((fn [x y]
+                   [x y]) a b))
+           1 2)]
+    (is (= a 1))
+    (is (= b 2))
+    (is (= x 1))
+    (is (= y 2)))
+  (let [_ ((*fn [a b]
+                ((fn ([x] x)
+                   ([x y] [x y])) a b))
+           1 2)]
+    (is (= a 1))
+    (is (= b 2))
+    (is (= x 1))
+    (is (= y 2))))
 
+
+:clj( (defmacro let-to-fn [bindings & body]
+    (->> (partition 2 bindings)
+         reverse
+         (reduce (fn [acc [binding-sym val]]
+                   (if (= acc body)
+                     `((fn [~binding-sym] ~@acc) ~val)
+                     `((fn [~binding-sym] ~acc) ~val)))
+                 body))) 
+(comment
+  (macroexpand-1 '(let-to-fn [a 1 b 2]
+                             (+ a b))))
+
+
+
+(deftest custom-let-macros
+  (let [_ (defn* fn-with-custom-let-macro [x]
+            (let-to-fn [y x
+                        z (inc x)]
+                       (+ x z)))
+        _ (fn-with-custom-let-macro 10)]
+    (is (= y 10))
+    (is (= z 11)))))
+(defn* foobar [a]
+  ((fn [b] b) a))
 
 (comment
-   (macroexpand-1 '(defn* foo [{:keys [a]}]
-       a) )
-   (foo 1)
+  (macroexpand-1 '(defn* foo [{:keys [a]}]
+                    a))
+  (foo 1)
 
- (macroexpand-1 '(defn* foo1 [{:keys [a/foo1-b1 foo1-c2]
-                 foo1-dee3 :d
-                 :as foo1-m4}
-                [foo1-x5 [foo1-y6 [foo1-z7]]]]
-     [foo1-b1 foo1-c2 foo1-dee3 foo1-m4 foo1-x5 foo1-y6 foo1-z7]) )
+  (macroexpand-1 '(defn* foo1 [{:keys [a/foo1-b1 foo1-c2]
+                                foo1-dee3 :d
+                                :as foo1-m4}
+                               [foo1-x5 [foo1-y6 [foo1-z7]]]]
+                    [foo1-b1 foo1-c2 foo1-dee3 foo1-m4 foo1-x5 foo1-y6 foo1-z7]))
 
- (defn* foo1> [{:keys [a/b1 c2]
+  (defn* foo1> [{:keys [a/b1 c2]
                  dee3 :d3
                  :as m4}
                 [x5 [y6 [z7]]]]
-     [b1 c2 dee3 m4 x5 y6 z7])
+    [b1 c2 dee3 m4 x5 y6 z7])
 
 
 
- (defn ^:private unmap-vars-for-fn!
-   "Will unmap vars that have been globally defined by defn*.
+  (defn ^:private unmap-vars-for-fn!
+    "Will unmap vars that have been globally defined by defn*.
    This only works with the test functions, because the test functions
    follow the convention of fn-name-arg-name.
    for e.g
@@ -282,11 +327,14 @@
        [bar-arg1 bar-arg2]))
 
    `fn-name` is a symbol."
-   [fn-name]
-   (mapv (partial ns-unmap 'snitch.core-test)
-         (filterv #(s/starts-with? (str %) (str fn-name))
-                  (keys (ns-publics 'snitch.core-test)))))
+    [fn-name]
+    (mapv (partial ns-unmap 'snitch.core-test)
+          (filterv #(s/starts-with? (str %) (str fn-name))
+                   (keys (ns-publics 'snitch.core-test)))))
 
 
- (filter #(clojure.string/starts-with? (str %) "foo3") (keys (ns-publics 'snitch.core-test)) )
-   (map #(ns-unmap 'snitch.core-test %) (keys (ns-publics 'snitch.core-test)) ))
+  (filter #(clojure.string/starts-with? (str %) "foo3") (keys (ns-publics 'snitch.core-test)))
+  (map #(ns-unmap 'snitch.core-test %) (keys (ns-publics 'snitch.core-test))))
+
+
+


### PR DESCRIPTION
- Changed the underlying implementation of defn* and fn*. Initially fn* would just call defn* and "edit" the macroexpansion, it depended on defn*. In order to support inline defs in lambdas defined inside a function, I swapped their definitions.
- After I call macroexpand on the input forms, I replace all instances of `fn` with `*fn`.
- 
